### PR TITLE
snyk critical issue: remote code execution fix

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 Flask==3.0.2
+werkzeug==3.0.3
 beautifulsoup4==4.13.4
 requests==2.32.3
 flask_cors


### PR DESCRIPTION
Followed snyk recommended action to pin werkzeug version to 3.0.3